### PR TITLE
Filename Parsing

### DIFF
--- a/res/options/parts.json
+++ b/res/options/parts.json
@@ -45,7 +45,6 @@
             "Percussion",
             "Snare Drum",
             "Marching, Tenor Drums",
-            "Marching, Tenor Drums",
             "Marching Tenor Drums",
             "Marching\nTenor Drums",
             "Bass Drum",

--- a/res/options/parts.json
+++ b/res/options/parts.json
@@ -44,7 +44,21 @@
             "Drum Set",
             "Percussion",
             "Snare Drum",
-            "Marching, Tenor Drums"
+            "Marching, Tenor Drums",
+            "Marching, Tenor Drums",
+            "Marching Tenor Drums",
+            "Marching\nTenor Drums",
+            "Bass Drum",
+            "Cymbals",
+            "Timbales",
+            "Claves",
+            "Guiro",
+            "G\u00fciro",
+            "Gourd",
+            "Handclap",
+            "Clap",
+            "CL",
+            "Cl"
         ]
     },
     "exclude": [

--- a/scripts/redvest_creator.py
+++ b/scripts/redvest_creator.py
@@ -63,7 +63,7 @@ def add_individual_parts(service, parts_id, audio_id, section_ids, alias_map):
             _, part, _ = util.parse_file(item.get('name'), alias_map)
 
             # Part mapping doesn't exist
-            if (not part):
+            if (part == util.NO_PART or not part):
                 print(f'WARNING: Cannot add "{item.get("name")}" - part not found')
                 continue
             

--- a/scripts/util/lib_management.py
+++ b/scripts/util/lib_management.py
@@ -31,7 +31,7 @@ def add_file(service, file_name, separated_ids, alias_map, cache, options):
         sep_dest_parent = None
         sep_dest_title = "None"
 
-        if mimeType == 'application/pdf' or file_name.endswith('.sib'):
+        if mimeType == 'application/pdf' or file_name.endswith('.pdf'):
             upload_dest = parts_id
             sep_dest_parent = sep_sec_id
             sep_dest_title = "Separated Section Parts"
@@ -44,6 +44,9 @@ def add_file(service, file_name, separated_ids, alias_map, cache, options):
             return False
         
         file_id = util.upload_file(service, os.path.join(directory, file_name), file_name, upload_dest, mime_type=mimeType)
+        if part == util.NO_PART:
+            print(f'WARNING: No matching part found for "{file_name}"')
+            return True
         sep_dest_ids = util.get_folder_ids(service, name=part, parent=sep_dest_parent)
         if sep_dest_ids == None:
             print(f'WARNING: Unable to create shortcut in {sep_dest_title} for "{file_name}"')

--- a/scripts/util/remake_utils.py
+++ b/scripts/util/remake_utils.py
@@ -69,7 +69,7 @@ def write_shortcuts(service, chartname, id, age, new_folders, alias_map):
         check_stop_script()
         partfile_name = partfile.get('name')
         _, part, _ = util.parse_file(partfile_name, alias_map)
-        if part == None:
+        if part == None or part == util.NO_PART:
             print(f'WARNING: Part file "{partfile_name}" has no matching part folder')
             continue
         
@@ -87,7 +87,7 @@ def write_shortcuts(service, chartname, id, age, new_folders, alias_map):
         check_stop_script()
         audiofile_name = audiofile.get('name')
         _, part, _ = util.parse_file(audiofile_name, alias_map)
-        if part == None:
+        if part == None or part == util.NO_PART:
             print(f'WARNING: Audio file "{audiofile_name}" has no matching part folder')
             continue
 

--- a/scripts/util/util.py
+++ b/scripts/util/util.py
@@ -6,6 +6,9 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 
+# Value to represent no part
+NO_PART = "NO_PART"
+
 # Custom Exception for when credentials fail to load
 class CredentialsError(Exception):
     pass
@@ -119,7 +122,7 @@ def parse_file(filename, alias_map=None):
     # title - part format
     match = re.search('(.*) - (.*)\.(.*)', filename)
     if match:
-        return match.group(1), alias_map.get(match.group(2)) if alias_map else None, mimetypes.guess_type(filename)[0]
+        return match.group(1), (alias_map.get(match.group(2)) or NO_PART) if alias_map else None, mimetypes.guess_type(filename)[0]
 
 
     # other file type format


### PR DESCRIPTION
Files added by the upload files script that match the regex 'filename - partname' but whose part name is not found in the alias map will now be added to the parts/audio folder (but not to seperated part/audio folders). A warning will be printed upon upload, and will also be displayed when running remake shortcuts or redvest creator.